### PR TITLE
Support address=lat,lng without going to google.

### DIFF
--- a/converters.py
+++ b/converters.py
@@ -188,7 +188,7 @@ class AddressConverter(object):
                 "lng" : lng,
             }]
         except ValueError:
-            pass
+            return None
 
 
 class WardAddressConverter(AddressConverter):


### PR DESCRIPTION
The coincidental support for this broke when we started forcing ", south africa" onto the end of the string. But this saves us a trip to google in any case.
